### PR TITLE
Document release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,7 @@ jobs:
     if: github.event_name == 'release'
     needs: test
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 3.0.1
+
+- Migrated the package build to Bun and TypeScript declaration output.
+- Added public project documentation, security reporting guidance, and contribution guidance.
+- Added CI coverage for Parse Server integration tests with MongoDB.
+- Prepared npm publishing through GitHub Releases and npm trusted publishing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for taking the time to improve Parse Server Schema Manager.
 
 ## Local Setup
 
+Integration tests require MongoDB at `mongodb://127.0.0.1:27017/schema-test`.
+
 ```shell
 bun install
 bun run type-check
@@ -20,6 +22,10 @@ The integration tests start a local Parse Server test environment through `test/
 3. Add or update tests for behavior changes.
 4. Run `bun run ci` before opening the pull request.
 5. Describe the user-facing behavior change and any migration notes.
+
+## Releases
+
+Release PRs should update `package.json`, `CHANGELOG.md`, and any user-facing documentation that changed. Publishing happens from the GitHub Release workflow through npm trusted publishing, so do not add npm tokens to the workflow.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Pointer and relation fields should include `targetClass`.
 
 ## Development
 
+Integration tests expect MongoDB to be available at `mongodb://127.0.0.1:27017/schema-test`. The GitHub Actions workflow starts MongoDB as a service container; for local development, start MongoDB before running the test suite.
+
 ```shell
 bun install
 bun run type-check
@@ -185,7 +187,23 @@ bun run build
 npm pack --dry-run --ignore-scripts
 ```
 
-The package publishes the built `dist` files, `README.md`, and `LICENSE`. Run `bun run pack:check` before publishing to verify the npm package contents.
+The package publishes the built `dist` files, `README.md`, `CHANGELOG.md`, and `LICENSE`. Run `bun run pack:check` before publishing to verify the npm package contents.
+
+## Release
+
+Publishing is intentionally tied to GitHub Releases, not ordinary merges to `main`.
+
+1. Merge the release PR into `main`.
+2. Create and publish a GitHub Release with a tag that matches the package version, for example `v3.0.1`.
+3. The `release.published` workflow builds the package and runs `npm publish --provenance`.
+
+This repository uses npm trusted publishing through GitHub Actions OIDC. Do not add an `NPM_TOKEN` to the workflow. The npm trusted publisher should be configured for:
+
+- Repository: `vahidalizad/parse-server-schema-manager`
+- Workflow: `.github/workflows/cd.yml`
+- Environment: `npm`
+
+The publish job declares `id-token: write` and the `npm` environment so npm can verify the trusted publisher identity.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "packageManager": "bun@1.3.0",


### PR DESCRIPTION
## Summary
- document the GitHub Release publishing path and npm trusted publishing setup
- add a 3.0.1 changelog entry and include it in the npm package
- note the local MongoDB requirement for integration tests
- set the publish job environment to npm for trusted publisher matching

## Testing
- bun run type-check
- bun test test/integration
- bun run build
- npm pack --dry-run --ignore-scripts

## Release note
After this PR is merged, publish a GitHub Release tagged v3.0.1 to trigger npm trusted publishing. No NPM_TOKEN is required.